### PR TITLE
fix: missing permissions in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automate publishing Go build binary artifacts to GitHub releases through GitHub 
 
 ## Usage
 
-Your secret token might not have permissions to upload assets.
+Your secret token might not have permissions to upload assets. In that case do not forget to add `permissions` to your workflow file (see examples).
 
 ### Basic Example
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Automate publishing Go build binary artifacts to GitHub releases through GitHub 
 
 ## Usage
 
+Your secret token might not have permissions to upload assets.
+
 ### Basic Example
 
 Release single artifact for linux amd64 with default option when tag push.
@@ -22,6 +24,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Release code
-        uses: likexian/go-release-action@v0.7.0
+        uses: likexian/go-release-action@v0.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOS: linux
@@ -69,6 +74,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -83,7 +91,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Release code
-        uses: likexian/go-release-action@v0.7.0
+        uses: likexian/go-release-action@v0.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
There's a problem that the action reports success even though the assets are not actually uploaded, it's easy to miss this in logs:

```json
{"message":"Resource not accessible by integration","request_id":"<id>","documentation_url":"https://docs.github.com/rest"}
```

Ideally, the action should parse `status` and throw but my problem was caused by missing `permission` in my workflow. Let's add it to example to make sure ppl don't run into the same problem.